### PR TITLE
Refactor layout manager

### DIFF
--- a/config/frontier/cooling.json
+++ b/config/frontier/cooling.json
@@ -4,7 +4,6 @@
     "ZIP_CODE": 37831,
     "COUNTRY_CODE": "US",
     "FMU_PATH": "models/Simulator_olcf5_base.fmu",
-    "FMU_UPDATE_FREQ": 15,
     "FMU_COLUMN_MAPPING": {
         "T_sec_r_C": "Rack Return Temperature (\u00b0C)",
         "T_sec_s_C": "Rack Supply Temperature (\u00b0C)",

--- a/main.py
+++ b/main.py
@@ -97,13 +97,13 @@ else:
         power_manager = PowerManager(compute_node_power, **config)
 
 flops_manager = FLOPSManager(**config)
-layout_manager = LayoutManager(args.layout, args.debug, **config)
 args_dict['config'] = config
 sc = Scheduler(
-    power_manager = power_manager, flops_manager = flops_manager, layout_manager = layout_manager,
+    power_manager = power_manager, flops_manager = flops_manager,
     cooling_model = cooling_model,
     **args_dict,
 )
+layout_manager = LayoutManager(args.layout, scheduler = sc, debug = args.debug, **config)
 
 if args.replay:
 
@@ -173,7 +173,8 @@ if args.plot or args.output:
 if args.verbose:
     print(jobs)
 
-sc.run_simulation_blocking(jobs, timesteps=timesteps)
+layout_manager.run(jobs, timesteps=timesteps)
+
 output_stats = sc.get_stats()
 # Following b/c we get the following error when we use PM100 telemetry dataset
 # TypeError: Object of type int64 is not JSON serializable

--- a/raps/scheduler.py
+++ b/raps/scheduler.py
@@ -58,8 +58,8 @@ class TickData:
     jobs: list[Job]
     down_nodes: list[int]
     power_df: Optional[pd.DataFrame]
-    p_flops: float
-    g_flops_w: float
+    p_flops: Optional[float]
+    g_flops_w: Optional[float]
     system_util: float
     fmu_inputs: Optional[dict]
     fmu_outputs: Optional[dict]

--- a/raps/scheduler.py
+++ b/raps/scheduler.py
@@ -31,7 +31,6 @@ Config parameters used:
 - MAX_TIME: Maximum simulation time.
 - POWER_UPDATE_FREQ: Frequency of updating power-related metrics.
 - POWER_DF_HEADER: Header for the power related components of DataFrame.
-- FMU_UPDATE_FREQ: Frequency of updating the FMU model.
 - POWER_CDU: Power consumption of CDU.
 - TOTAL_NODES: Total number of nodes in the system.
 - COOLING_EFFICIENCY: Cooling efficiency factor.
@@ -290,7 +289,7 @@ class Scheduler:
 
         if self.cooling_model:
 
-            if self.current_time % self.config['FMU_UPDATE_FREQ'] == 0:
+            if self.current_time % self.config['POWER_UPDATE_FREQ'] == 0:
                 # Power for NUM_CDUS (25 for Frontier)
                 cdu_power = rack_power.T[-1] * 1000
                 runtime_values = self.cooling_model.generate_runtime_values(cdu_power, self)
@@ -299,7 +298,7 @@ class Scheduler:
                 fmu_inputs = self.cooling_model.generate_fmu_inputs(runtime_values, \
                              uncertainties=self.power_manager.uncertainties)
                 cooling_inputs, cooling_outputs =\
-                    self.cooling_model.step(self.current_time, fmu_inputs, self.config['FMU_UPDATE_FREQ'])
+                    self.cooling_model.step(self.current_time, fmu_inputs, self.config['POWER_UPDATE_FREQ'])
                 
                 # Get a dataframe of the power data
                 power_df = self.power_manager.get_power_df(rack_power, rack_loss)


### PR DESCRIPTION
This separates the view/ui logic from the simulation itself making it easier to swap out different UIs. It should also make
maintaining the server after RAPS updates easier as now both the server and the RAPS CLI use the same code path and TickData object.